### PR TITLE
Option to use stepper motor as a winder

### DIFF
--- a/Mackerel/Configuration.h
+++ b/Mackerel/Configuration.h
@@ -342,7 +342,7 @@ debug notes:
 #define EXTRUDER_RPM_PID_INTEGRATOR_WIND_LIMIT 100000000 //absolute value of integrator windup max value
 #define EXTRUDER_RPM_DT 1.0 //Time step for PID
 
-
+#define USE_WINDER_STEPPER
 
 #define DEFAULT_LENGTH_CUTOFF 150000  //length in mm where extruder will shut down
 

--- a/Mackerel/Configuration.h
+++ b/Mackerel/Configuration.h
@@ -342,7 +342,7 @@ debug notes:
 #define EXTRUDER_RPM_PID_INTEGRATOR_WIND_LIMIT 100000000 //absolute value of integrator windup max value
 #define EXTRUDER_RPM_DT 1.0 //Time step for PID
 
-#define USE_WINDER_STEPPER
+//#define USE_WINDER_STEPPER
 
 #define DEFAULT_LENGTH_CUTOFF 150000  //length in mm where extruder will shut down
 

--- a/Mackerel/Mackerel.h
+++ b/Mackerel/Mackerel.h
@@ -259,7 +259,7 @@ extern float min_pos[3];
 extern float max_pos[3];
 extern bool axis_known_position[3];
 extern float zprobe_zoffset;
-extern int winderSpeed;
+extern int winderOrFanSpeed;
 #ifdef BARICUDA
 extern int ValvePressure;
 extern int EtoPPressure;

--- a/Mackerel/Mackerel_main.cpp
+++ b/Mackerel/Mackerel_main.cpp
@@ -2270,8 +2270,8 @@ void process_commands()
             break;
           }
         }
-      #if defined(WINDER_PIN) && WINDER_PIN > -1
-        if (pin_number == WINDER_PIN)
+      #if defined(WINDER_OR_FAN_PIN) && WINDER_OR_FAN_PIN > -1
+        if (pin_number == WINDER_OR_FAN_PIN)
           winderOrFanSpeed = pin_status;
       #endif
         if (pin_number > -1)
@@ -2488,7 +2488,7 @@ void process_commands()
     #endif
         break;
 
-    #if defined(WINDER_PIN) && WINDER_PIN > -1
+    #if defined(WINDER_OR_FAN_PIN) && WINDER_OR_FAN_PIN > -1
       case 106: //M106 Fan On
         if (code_seen('S')){
            winderOrFanSpeed=constrain(code_value(),0,255);
@@ -2500,7 +2500,7 @@ void process_commands()
       case 107: //M107 Fan Off
         winderOrFanSpeed = 0;
         break;
-    #endif //WINDER_PIN
+    #endif //WINDER_OR_FAN_PIN
     #ifdef BARICUDA
       // PWM for HEATER_1_PIN
       #if defined(HEATER_1_PIN) && HEATER_1_PIN > -1
@@ -3826,7 +3826,7 @@ void prepare_arc_move(char isclockwise) {
 
 #if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
 
-#if defined(WINDER_PIN)
+#if defined(WINDER_OR_FAN_PIN)
   #if CONTROLLERFAN_PIN == FAN_PIN
     #error "You cannot set CONTROLLERFAN_PIN equal to FAN_PIN"
   #endif

--- a/Mackerel/Mackerel_main.cpp
+++ b/Mackerel/Mackerel_main.cpp
@@ -280,7 +280,7 @@ float extruder_offset[NUM_EXTRUDER_OFFSETS][EXTRUDERS] = {
 };
 #endif
 uint8_t active_extruder = 0;
-int winderSpeed=0;
+int winderOrFanSpeed=0;
 #ifdef SERVO_ENDSTOPS
   int servo_endstops[] = SERVO_ENDSTOPS;
   int servo_endstop_angles[] = SERVO_ENDSTOP_ANGLES;
@@ -364,6 +364,7 @@ static uint8_t tmp_extruder;
 
 static float extruder_increment;  //used to calculate the increment to add to create the next planning move for the extruder motor
 static float puller_increment; //used to calculate the increment to add to create the next planning move for the puller motor
+static float winder_increment; //used to calculate the increment to add to create the next planning move for the winder motor
 static unsigned long timebuff=0;
 static unsigned long deltatime=0;
 static unsigned long lasttime=0;
@@ -672,11 +673,11 @@ void loop()
   deltatime = timebuff-lasttime;  //calculate delta times
   lasttime = timebuff;  //keep track of last sample time
   
-
-  if(extrude_length < fil_length_cutoff)
-	  winderSpeed = default_winder_speed*255/winder_rpm_factor;  //keep winder on all the time unless at end of spool
-  
-
+#ifndef USE_WINDER_STEPPER
+  if(extrude_length < fil_length_cutoff) {
+	  winderOrFanSpeed = default_winder_speed*255/winder_rpm_factor;  //keep winder on all the time unless at end of spool
+  }
+#endif
   
   
   
@@ -695,7 +696,7 @@ void loop()
 	  
 	  if(extrude_length >= fil_length_cutoff){  //check whether we extruded enough filament
 		  setTargetHotend0(0);
-		  winderSpeed = 0;
+		  winderOrFanSpeed = 0;
 		  digitalWrite(CONTROLLERFAN_PIN, 0);  //stop Fan
 		  extrude_status= extrude_status & ES_ENABLE_CLEAR;  //update extrude_status to shut down extruder
 		  extrude_status= extrude_status & ES_STATS_CLEAR;  //shut down statistics
@@ -741,30 +742,18 @@ void loop()
   
   if((extrude_status & ES_ENABLE_SET) >0){
 	  
-	  
-	  
-	  
-	  
-	 //old 
-	 // feedrate=20*60;
-	 // extruder_increment=feedmultiply/100.0;
-	 // puller_increment=extruder_increment*pullermultiply/1000.0;
-	  
-	  //extruder_feedrate=feedrate*extruder_increment/60.0;
-	  //puller_feedrate=extruder_feedrate*pullermultiply/1000.0;
-	  
-	 //new
 	  extruder_increment=extruder_rpm_set/EXTRUDER_RPM_MAX*8;  //make extruder increment 1 unit for max RPM and scale down as RPM input decreases *8 for more duration (removes pulsing)
 	  extruder_feedrate=extruder_rpm_set/0.6;
 	  puller_increment=puller_feedrate*0.6/EXTRUDER_RPM_MAX*8;  //make puller increment vary to control it *8 for more duration (removes pulsing)
 	  
-	  
-	  
-	  
-	  
 	  //calculate move  - always scale step size to feedmultiply (was previously fix step side of 0.1)
 	  destination[P_AXIS] = puller_increment + current_position[P_AXIS]; //puller
-	  
+
+#ifdef USE_WINDER_STEPPER
+    winder_increment=default_winder_speed*0.6/EXTRUDER_RPM_MAX*8;  //We dont need the RMP factor because our stepper has no "default RPM". 
+                                                                   //RPM factor applies only non stepper mottors they have default RPM when supplied full voltage
+	  destination[X_AXIS] = winder_increment + current_position[X_AXIS]; //winder if enabled is using the X_AXIS
+#endif
 
 	  	  
 	  if((extrude_status & ES_HOT_SET) && (extrude_status & ES_SWITCH_SET))  //check that extruder is at temp and switch in on
@@ -942,9 +931,19 @@ void loop()
 	}  
 	  //send move
 	  previous_millis_cmd = millis();  //refresh the kill watchdog timer
-	  plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], destination[P_AXIS], feedrate, active_extruder);  //FMM added P_AXIS
+
+#ifndef USE_WINDER_STEPPER	
+    plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], destination[P_AXIS], feedrate, active_extruder);  //FMM added P_AXIS
 	  current_position[E_AXIS]=destination[E_AXIS];
-	  current_position[P_AXIS]=destination[P_AXIS];
+	  current_position[P_AXIS]=destination[P_AXIS]; 
+#else
+    int max_move_feedrate = max(extruder_feedrate, max(puller_feedrate, (float)default_winder_speed));
+	  plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], destination[P_AXIS], max_move_feedrate , active_extruder);  //FMM added P_AXIS
+	  
+    current_position[X_AXIS]=destination[X_AXIS];
+    current_position[E_AXIS]=destination[E_AXIS];
+	  current_position[P_AXIS]=destination[P_AXIS]; 
+#endif
   }
   else{
 	  extruder_increment=0;
@@ -973,7 +972,7 @@ void loop()
     MYSERIAL.print("MQTT:/FE/winder/val/");
     json_pair_first("ts_m",time_snap,0);
     json_pair("rpm",default_winder_speed,2);
-    json_pair_last("set",winderSpeed,2);
+    json_pair_last("set",winderOrFanSpeed,2);
     
     
     #ifdef FILAMENT_SENSOR
@@ -2273,7 +2272,7 @@ void process_commands()
         }
       #if defined(WINDER_PIN) && WINDER_PIN > -1
         if (pin_number == WINDER_PIN)
-          winderSpeed = pin_status;
+          winderOrFanSpeed = pin_status;
       #endif
         if (pin_number > -1)
         {
@@ -2492,14 +2491,14 @@ void process_commands()
     #if defined(WINDER_PIN) && WINDER_PIN > -1
       case 106: //M106 Fan On
         if (code_seen('S')){
-           winderSpeed=constrain(code_value(),0,255);
+           winderOrFanSpeed=constrain(code_value(),0,255);
         }
         else {
-          winderSpeed=255;
+          winderOrFanSpeed=255;
         }
         break;
       case 107: //M107 Fan Off
-        winderSpeed = 0;
+        winderOrFanSpeed = 0;
         break;
     #endif //WINDER_PIN
     #ifdef BARICUDA
@@ -2562,7 +2561,7 @@ void process_commands()
         disable_p();
         disable_e2();
         finishAndDisableSteppers();
-        winderSpeed = 0;
+        winderOrFanSpeed = 0;
         delay(1000); // Wait a little before to switch off
       #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
         st_synchronize();
@@ -3466,7 +3465,7 @@ void process_commands()
 		SERIAL_PROTOCOL_F(puller_feedrate, 2);
 		// Winder speed
 		SERIAL_PROTOCOLPGM(" W:");
-		SERIAL_PROTOCOL(winderSpeed);
+		SERIAL_PROTOCOL(winderOrFanSpeed);
 		//
 #if defined(TEMP_0_PIN) && TEMP_0_PIN > -1
 //		SERIAL_PROTOCOLPGM(" T:");
@@ -3668,14 +3667,19 @@ void get_arc_coordinates()
 
 void clamp_to_software_endstops(float target[3])
 {
+  //when using X axis as winder we don't need the endstops
   if (min_software_endstops) {
+#ifndef USE_WINDER_STEPPER
     if (target[X_AXIS] < min_pos[X_AXIS]) target[X_AXIS] = min_pos[X_AXIS];
+#endif
     if (target[Y_AXIS] < min_pos[Y_AXIS]) target[Y_AXIS] = min_pos[Y_AXIS];
     if (target[Z_AXIS] < min_pos[Z_AXIS]) target[Z_AXIS] = min_pos[Z_AXIS];
   }
 
   if (max_software_endstops) {
+#ifndef USE_WINDER_STEPPER
     if (target[X_AXIS] > max_pos[X_AXIS]) target[X_AXIS] = max_pos[X_AXIS];
+#endif
     if (target[Y_AXIS] > max_pos[Y_AXIS]) target[Y_AXIS] = max_pos[Y_AXIS];
     if (target[Z_AXIS] > max_pos[Z_AXIS]) target[Z_AXIS] = max_pos[Z_AXIS];
   }

--- a/Mackerel/Mackerel_main.cpp
+++ b/Mackerel/Mackerel_main.cpp
@@ -674,7 +674,7 @@ void loop()
   lasttime = timebuff;  //keep track of last sample time
   
 #ifndef USE_WINDER_STEPPER
-  if(extrude_length < fil_length_cutoff) {
+  if(extrude_length < fil_length_cutoff && (extrude_status & ES_ENABLE_SET)) {
 	  winderOrFanSpeed = default_winder_speed*255/winder_rpm_factor;  //keep winder on all the time unless at end of spool
   }
 #endif

--- a/Mackerel/language.h
+++ b/Mackerel/language.h
@@ -104,6 +104,7 @@
 	#define MSG_MOVE_Z "Move Z"
 	#define MSG_MOVE_E "Extruder"
 	#define MSG_MOVE_P "Puller"
+	#define MSG_MOVE_W "Winder"
 	#define MSG_MOVE_01MM "Move 0.1mm"
 	#define MSG_MOVE_1MM "Move 1mm"
 	#define MSG_MOVE_10MM "Move 10mm"

--- a/Mackerel/pins.h
+++ b/Mackerel/pins.h
@@ -513,7 +513,7 @@
   #if MOTHERBOARD == 33 || MOTHERBOARD == 35 || MOTHERBOARD == 67 || MOTHERBOARD == 68
     #define FAN_PIN            9 // (Sprinter config)
   #else
-    #define WINDER_PIN            8 // FMM used for the winder motor
+    #define WINDER_OR_FAN_PIN            8 // FMM used for the winder motor
   #endif
 
   #if MOTHERBOARD == 77
@@ -2591,7 +2591,7 @@
 #endif
 
 #define SENSITIVE_PINS {0, 1, X_STEP_PIN, X_DIR_PIN, X_ENABLE_PIN, X_MIN_PIN, X_MAX_PIN, Y_STEP_PIN, Y_DIR_PIN, Y_ENABLE_PIN, Y_MIN_PIN, Y_MAX_PIN, Z_STEP_PIN, Z_DIR_PIN, Z_ENABLE_PIN, Z_MIN_PIN, Z_MAX_PIN, PS_ON_PIN, \
-                        HEATER_BED_PIN, WINDER_PIN,                  \
+                        HEATER_BED_PIN, WINDER_OR_FAN_PIN,                  \
                         _E0_PINS _P_PINS _E2_PINS             \
                         analogInputToDigitalPin(TEMP_0_PIN), analogInputToDigitalPin(TEMP_1_PIN), analogInputToDigitalPin(TEMP_2_PIN), analogInputToDigitalPin(TEMP_BED_PIN) }
 #endif

--- a/Mackerel/planner.cpp
+++ b/Mackerel/planner.cpp
@@ -450,7 +450,7 @@ void check_axes_activity()
   unsigned char z_active = 0;
   unsigned char e_active = 0;
   unsigned char p_active = 0;
-  unsigned char tail_winder_speed = winderSpeed;
+  unsigned char tail_winder_speed = winderOrFanSpeed;
   #ifdef BARICUDA
   unsigned char tail_valve_pressure = ValvePressure;
   unsigned char tail_e_to_p_pressure = EtoPPressure;
@@ -615,7 +615,7 @@ block->steps_y = labs((target[X_AXIS]-position[X_AXIS]) - (target[Y_AXIS]-positi
     return; 
   }
 
-  block->winder_speed = winderSpeed;
+  block->winder_speed = winderOrFanSpeed;
   #ifdef BARICUDA
   block->valve_pressure = ValvePressure;
   block->e_to_p_pressure = EtoPPressure;

--- a/Mackerel/planner.cpp
+++ b/Mackerel/planner.cpp
@@ -485,7 +485,7 @@ void check_axes_activity()
     disable_e0();
     disable_e2(); 
   }
-#if defined(WINDER_PIN) && WINDER_PIN > -1
+#if defined(WINDER_OR_FAN_PIN) && WINDER_OR_FAN_PIN > -1
   #ifdef FAN_KICKSTART_TIME
     static unsigned long fan_kick_end;
     if (tail_fan_speed) {
@@ -503,9 +503,9 @@ void check_axes_activity()
   #ifdef FAN_SOFT_PWM
   fanSpeedSoftPwm = tail_fan_speed;
   #else
-  analogWrite(WINDER_PIN,tail_winder_speed);
+  analogWrite(WINDER_OR_FAN_PIN, tail_winder_speed);
   #endif//!FAN_SOFT_PWM
-#endif//WINDER_PIN > -1
+#endif//WINDER_OR_FAN_PIN > -1
 #ifdef AUTOTEMP
   getHighESpeed();
 #endif

--- a/Mackerel/stepper.cpp
+++ b/Mackerel/stepper.cpp
@@ -351,7 +351,7 @@ ISR(TIMER1_COMPA_vect)
     out_bits = current_block->direction_bits;
 
 //FMM Disable X,Y,Z output
-/*   
+  
     // Set the direction bits (X_AXIS=A_AXIS and Y_AXIS=B_AXIS for COREXY)
     if((out_bits & (1<<X_AXIS))!=0){
       #ifdef DUAL_X_CARRIAGE
@@ -454,6 +454,7 @@ ISR(TIMER1_COMPA_vect)
       }
     }
 
+/* No need for Y and Z axes sofar
     #ifndef COREXY
     if ((out_bits & (1<<Y_AXIS)) != 0) {   // -direction
     #else
@@ -529,8 +530,8 @@ ISR(TIMER1_COMPA_vect)
         #endif
       }
     }
-
-    */  // FMM disable x,y,z endstop checking to improve pulse speed.
+*/
+    // FMM disable x,y,z endstop checking to improve pulse speed.
     
     #ifndef ADVANCE
       if ((out_bits & (1<<E_AXIS)) != 0) {  // -direction
@@ -582,7 +583,7 @@ ISR(TIMER1_COMPA_vect)
       }
       #endif //ADVANCE
 
-      /*//disable x
+    //write x axis
         counter_x += current_block->steps_x;
         if (counter_x > 0) {
         #ifdef DUAL_X_CARRIAGE
@@ -616,7 +617,7 @@ ISR(TIMER1_COMPA_vect)
           WRITE(X_STEP_PIN, INVERT_X_STEP_PIN);
         #endif
         }
-*/  //end disable x
+  //end write x axis
       
       /*//disable y
         counter_y += current_block->steps_y;

--- a/Mackerel/temperature.cpp
+++ b/Mackerel/temperature.cpp
@@ -335,7 +335,7 @@ int getHeaterPower(int heater) {
     (defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1) || \
     (defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1)
 
-  #if defined(WINDER_PIN) && WINDER_PIN > -1
+  #if defined(WINDER_OR_FAN_PIN) && WINDER_OR_FAN_PIN > -1
     #if EXTRUDER_0_AUTO_FAN_PIN == FAN_PIN 
        #error "You cannot set EXTRUDER_0_AUTO_FAN_PIN equal to FAN_PIN"
     #endif
@@ -524,7 +524,7 @@ void manage_heater()
   previous_millis_bed_heater = millis();
   #endif
 
- // #if TEMP_SENSOR_BED != 0
+// #if TEMP_SENSOR_BED != 0
   
  // #ifdef PIDTEMPBED
  
@@ -803,10 +803,10 @@ void tp_init()
   #if defined(HEATER_BED_PIN) && (HEATER_BED_PIN > -1) 
     SET_OUTPUT(HEATER_BED_PIN);
   #endif  
-  #if defined(WINDER_PIN) && (WINDER_PIN > -1) 
-    SET_OUTPUT(WINDER_PIN);
+  #if defined(WINDER_OR_FAN_PIN) && (WINDER_OR_FAN_PIN > -1) 
+    SET_OUTPUT(WINDER_OR_FAN_PIN);
     #ifdef FAST_PWM_FAN
-    setPwmFrequency(WINDER_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
+    setPwmFrequency(WINDER_OR_FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
     #endif
     #ifdef FAN_SOFT_PWM
     soft_pwm_fan = fanSpeedSoftPwm / 2;

--- a/Mackerel/ultralcd.cpp
+++ b/Mackerel/ultralcd.cpp
@@ -321,7 +321,14 @@ static void lcd_extruder_resume()
 {
 	//feedmultiply=DEFAULT_FEEDMULTIPLY;
 	puller_feedrate = puller_feedrate_default;   //use default feed rate
-	extrude_status=extrude_status|ES_ENABLE_SET;
+
+    for(int8_t i=0; i < NUM_AXIS; i++) {
+        current_position[i] = 0;
+    }
+
+    plan_set_position(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], current_position[P_AXIS]);
+
+	extrude_status=extrude_status|ES_ENABLE_SET;  
 
 #ifndef USE_WINDER_STEPPER
 	winderOrFanSpeed = default_winder_speed*255/winder_rpm_factor;  //start winder DC motor

--- a/Mackerel/ultralcd.cpp
+++ b/Mackerel/ultralcd.cpp
@@ -309,16 +309,24 @@ static void lcd_extruder_pause()
     extrude_status=extrude_status & ES_ENABLE_CLEAR;
     puller_feedrate_default = puller_feedrate;   //save default feed rate
 
-    
+#ifndef USE_WINDER_STEPPER
+	winderOrFanSpeed = 0;  //turns off the DC puller motor
+#endif
+
     digitalWrite(CONTROLLERFAN_PIN, 0); //stop fan
     lcd_disable_statistics();
 }
+
 static void lcd_extruder_resume()
 {
 	//feedmultiply=DEFAULT_FEEDMULTIPLY;
 	puller_feedrate = puller_feedrate_default;   //use default feed rate
 	extrude_status=extrude_status|ES_ENABLE_SET;
-	winderOrFanSpeed = default_winder_speed*255/winder_rpm_factor;  //start winder
+
+#ifndef USE_WINDER_STEPPER
+	winderOrFanSpeed = default_winder_speed*255/winder_rpm_factor;  //start winder DC motor
+#endif
+
 	digitalWrite(CONTROLLERFAN_PIN, 1);  //start Fan
     starttime=millis();
     lcd_enable_statistics();
@@ -563,7 +571,8 @@ void lcd_preheat_pla0()
 {
     setTargetHotend0(plaPreheatHotendTemp);
     setTargetBed(plaPreheatHPBTemp);
-    winderOrFanSpeed = plaPreheatFanSpeed;
+
+    LCD_MESSAGEPGM("Extruder Warming Up");
     lcd_return_to_status();
     setWatch(); // heater sanity check timer
 }

--- a/Mackerel/ultralcd.cpp
+++ b/Mackerel/ultralcd.cpp
@@ -744,7 +744,7 @@ static void lcd_prepare_menu()
         MENU_ITEM(gcode, MSG_SWITCH_PS_ON, PSTR("M80"));
     }
 #endif
-  //  MENU_ITEM(submenu, MSG_MOVE_AXIS, lcd_move_menu);  //FMM remove the move functionality from the menu
+    MENU_ITEM(submenu, MSG_MOVE_AXIS, lcd_move_menu);  //FMM remove the move functionality from the menu
     END_MENU();
 }
 
@@ -914,13 +914,13 @@ static void lcd_move_menu_axis()
     MENU_ITEM(back, MSG_MOVE_AXIS, lcd_move_menu);
     MENU_ITEM(submenu, MSG_MOVE_E, lcd_move_e);
     MENU_ITEM(submenu, MSG_MOVE_P, lcd_move_p);
-   // MENU_ITEM(submenu, MSG_MOVE_X, lcd_move_x);
-   // MENU_ITEM(submenu, MSG_MOVE_Y, lcd_move_y);
-   // if (move_menu_scale < 10.0)
-   // {
-   //     MENU_ITEM(submenu, MSG_MOVE_Z, lcd_move_z);
+   MENU_ITEM(submenu, MSG_MOVE_X, lcd_move_x);
+   MENU_ITEM(submenu, MSG_MOVE_Y, lcd_move_y);
+   if (move_menu_scale < 10.0)
+   {
+       MENU_ITEM(submenu, MSG_MOVE_Z, lcd_move_z);
         
-   // }
+   }
     END_MENU();
 }
 


### PR DESCRIPTION
This pullrequest implements an option to use `X` axis stepper motor as a winder instead of `Pin 8` DC 12V motor by uncomenting `#define USE_STEPPER_WINDER` in the configuration.h file. `Pin 8` then works as ordinary cooling fan. 
This implements feature described in #15.

When working on the feature I found 2 bugs that i fixed:

- When motion menu was used to move an axis, the planner used old current position of `X` or `Y` or `Z` axes to plan unwanted move when extrusion was resumed. The issue was fixed by clearing the stepper positions besore resuming the extrusion.

- When DC motor winder on `Pin 8` was used  the winder did not stop when extrusion was paused. Thus the winder became unstoppable. I fixed the issue by setting `winderSpeed` to `0` and in the main loop the speed is set to `winderSpeed` only if `extrude_state` is enabled.